### PR TITLE
Prevent sending link if issue send as link

### DIFF
--- a/bot/scripts/jira/jira.js
+++ b/bot/scripts/jira/jira.js
@@ -3,7 +3,10 @@ const messages = require('./messages')
 module.exports = {
   sendIssueLink: (res) => {
     for (const match of res.match) {
-      res.send(messages.issueLink(match))
+      const issueLink = messages.issueLink(match)
+      if (!res.message.text.includes(issueLink)) {
+        res.send(issueLink)
+      }
     }
   },
 }

--- a/bot/scripts/jira/jira.ut.js
+++ b/bot/scripts/jira/jira.ut.js
@@ -32,7 +32,7 @@ describe('jira', () => {
   })
 })
 
-describe('hubot script', () => {
+describe('jira hubot script', () => {
   let jira
   let robot
 

--- a/bot/scripts/jira/jira.ut.js
+++ b/bot/scripts/jira/jira.ut.js
@@ -32,9 +32,10 @@ describe('jira', () => {
       expect(res.send).to.have.been.calledWith(messages.issueLink('RX-1234'))
       expect(res.send).to.have.been.calledWith(messages.issueLink('RX-2345'))
     })
+
     it('should not send issue link if the link is already part of the message', () => {
       res.match = ['RX-1234', 'RX-2345']
-      res.message.text = messages.issueLink('RX-1234')
+      res.message.text = `Irrelevant text ${messages.issueLink('RX-1234')} and RX-2345`
       sendIssueLink(res)
 
       expect(res.send).to.have.callCount(1)

--- a/bot/scripts/jira/jira.ut.js
+++ b/bot/scripts/jira/jira.ut.js
@@ -17,6 +17,9 @@ describe('jira', () => {
     res = {
       send: sinon.stub(),
       match: [],
+      message: {
+        text: '',
+      },
     }
   })
 
@@ -27,6 +30,14 @@ describe('jira', () => {
 
       expect(res.send).to.have.callCount(2)
       expect(res.send).to.have.been.calledWith(messages.issueLink('RX-1234'))
+      expect(res.send).to.have.been.calledWith(messages.issueLink('RX-2345'))
+    })
+    it('should not send issue link if the link is already part of the message', () => {
+      res.match = ['RX-1234', 'RX-2345']
+      res.message.text = messages.issueLink('RX-1234')
+      sendIssueLink(res)
+
+      expect(res.send).to.have.callCount(1)
       expect(res.send).to.have.been.calledWith(messages.issueLink('RX-2345'))
     })
   })


### PR DESCRIPTION
This PR by @phueper prevents nextbot from sending issue links if the issue was already send as a link.

Examples:
```
# Send link
RX-1234
```

```
# Do not send link
https://jira.actano.de/browse/RX-1234
```

```
# Only send link for RX-2345
https://jira.actano.de/browse/RX-1234 and RX-2345
```