### PR TITLE
Notify only for shrinkwrap changes in the master branch

### DIFF
--- a/bot/scripts/github-event-notifier/event-actions/push.js
+++ b/bot/scripts/github-event-notifier/event-actions/push.js
@@ -2,10 +2,10 @@ const messages = require('../messages')
 const flatMap = require('lodash/fp/flatMap')
 
 module.exports = (data, callback) => {
-  const { commits } = data
+  const { commits, ref } = data
   const modifiedFiles = flatMap((commit) => commit.modified, commits)
 
-  if (modifiedFiles.indexOf('npm-shrinkwrap.json') !== -1) {
+  if (ref === 'refs/heads/master' && modifiedFiles.indexOf('npm-shrinkwrap.json') !== -1) {
     const fullName = data.repository.full_name
     const chatMessage = messages.shrinkwrap(fullName)
     callback(chatMessage)

--- a/bot/scripts/github-event-notifier/event-actions/push.ut.js
+++ b/bot/scripts/github-event-notifier/event-actions/push.ut.js
@@ -14,11 +14,12 @@ describe('github-event: push', () => {
   let callback
   let data
   const modified = memo().is(() => [])
+  const ref = memo().is(() => 'refs/heads/master')
 
   beforeEach(() => {
     callback = sinon.stub()
     data = {
-      ref: 'refs/heads/my-branch',
+      ref: ref(),
       repository: {
         full_name: 'orga/repo',
       },
@@ -50,6 +51,17 @@ describe('github-event: push', () => {
       'index.js',
     ])
 
+    it('should not notify', () => {
+      push(data, callback)
+      expect(callback).to.not.have.been.called
+    })
+  })
+
+  describe('changed shrinkwrap on non-master branch', () => {
+    modified.is(() => [
+      'npm-shrinkwrap.json',
+    ])
+    ref.is(() => 'refs/heads/other-branch')
     it('should not notify', () => {
       push(data, callback)
       expect(callback).to.not.have.been.called


### PR DESCRIPTION
This change limits nextbot to only notify when a change of the shrinkwrap.json file is detected on the `master` branch. Any other branch will be ignored.